### PR TITLE
fix: restore Add to favorites on GitOps detail pages

### DIFF
--- a/src/gitops/components/shared/FavoriteButton/FavoriteButton.tsx
+++ b/src/gitops/components/shared/FavoriteButton/FavoriteButton.tsx
@@ -15,7 +15,7 @@ import {
 } from '@patternfly/react-core';
 import { ModalVariant } from '@patternfly/react-core/deprecated';
 import { Modal as PfModal, ModalProps as PfModalProps } from '@patternfly/react-core/deprecated';
-import { StarIcon } from '@patternfly/react-icons';
+import { OutlinedStarIcon, StarIcon } from '@patternfly/react-icons';
 
 import { useUserSettingsCompatibility } from './useUserSettingsCompatibility';
 
@@ -34,7 +34,9 @@ const Modal: React.FC<ModalProps> = ({ isFullScreen = false, className, ...props
   <PfModal
     {...props}
     className={cx('ocs-modal', className)}
-    appendTo={() => (isFullScreen ? document.body : document.querySelector('#modal-container'))}
+    appendTo={() =>
+      isFullScreen ? document.body : (document.querySelector('#modal-container') ?? document.body)
+    }
   />
 );
 
@@ -101,7 +103,8 @@ export const FavoriteButton = ({ defaultName }: FavoriteButtonProps) => {
     setIsModalOpen(false);
   };
 
-  const handleConfirmStar = () => {
+  const handleConfirmStar = (e?: React.FormEvent) => {
+    e?.preventDefault();
     const trimmedName = name.trim();
     if (!trimmedName) {
       setError(t('Name is required.'));
@@ -157,7 +160,7 @@ export const FavoriteButton = ({ defaultName }: FavoriteButtonProps) => {
     <div className="co-fav-actions-icon">
       <Tooltip content={tooltipText} position="top">
         <Button
-          icon={<StarIcon color={isStarred ? 'gold' : 'gray'} />}
+          icon={isStarred ? <StarIcon color="gold" /> : <OutlinedStarIcon />}
           className="co-xl-icon-button"
           data-test="favorite-button"
           variant="plain"
@@ -188,10 +191,10 @@ export const FavoriteButton = ({ defaultName }: FavoriteButtonProps) => {
           ]}
           variant={ModalVariant.small}
         >
-          <Form id="confirm-favorite-form" onSubmit={handleConfirmStar}>
+          <Form id="confirm-favorite" onSubmit={handleConfirmStar}>
             <FormGroup label={t('Name')} isRequired fieldId="input-name">
               <TextInput
-                id="confirm-favorite-form-name"
+                id="input-name"
                 data-test="input-name"
                 name="name"
                 type="text"

--- a/src/gitops/components/shared/FavoriteButton/FavoriteButton.tsx
+++ b/src/gitops/components/shared/FavoriteButton/FavoriteButton.tsx
@@ -35,7 +35,7 @@ const Modal: React.FC<ModalProps> = ({ isFullScreen = false, className, ...props
     {...props}
     className={cx('ocs-modal', className)}
     appendTo={() =>
-      isFullScreen ? document.body : (document.querySelector('#modal-container') ?? document.body)
+      isFullScreen ? document.body : document.querySelector('#modal-container') ?? document.body
     }
   />
 );


### PR DESCRIPTION
On Application, ApplicationSet, and AppProject detail pages, the favourites icon appeared as a grey filled star instead of an outline star, and clicking it did not open the add-to-favourites dialog, so users could not save the page to favourites.

Before:

<img width="1615" height="631" alt="Screenshot 2026-05-21 at 9 07 37 PM" src="https://github.com/user-attachments/assets/8195186c-80c6-4afc-a7bb-679a9f492567" />

Could not Add to 

<img width="1876" height="711" alt="Screenshot 2026-05-21 at 9 08 13 PM" src="https://github.com/user-attachments/assets/a3a74256-366b-40e3-b822-a261af7bf6cd" />
Favourite:


After:

<img width="1608" height="732" alt="Screenshot 2026-05-21 at 9 03 06 PM" src="https://github.com/user-attachments/assets/e4ebb6d4-b7d0-4d58-a817-b15d65e90a4f" />

Successfully Added to Favourites: 
<img width="1914" height="860" alt="Screenshot 2026-05-21 at 9 03 38 PM" src="https://github.com/user-attachments/assets/f2f01f7f-d9a6-4837-a003-aa3063f89280" />


